### PR TITLE
use cfn-signal

### DIFF
--- a/devbox-setup.sh
+++ b/devbox-setup.sh
@@ -171,7 +171,19 @@ cat > /home/ec2-user/.local/share/code-server/User/settings.json << EOF
   "window.menuBarVisibility": "classic",
   "workbench.startupEditor": "none",
   "workspace.openFilesInNewWindow": "off",
-  "workbench.colorTheme": "Default Dark+"
+  "workbench.colorTheme": "Default Dark+",
+  "extensions.autoUpdate": false,
+  "extensions.autoCheckUpdates": false,
+  "telemetry.telemetryLevel": "off",
+  "security.workspace.trust.startupPrompt": "never",
+  "security.workspace.trust.enabled": false,
+  "security.workspace.trust.banner": "never",
+  "security.workspace.trust.emptyWindow": false,
+  "auto-run-command.rules": [
+    {
+      "command": "workbench.action.terminal.new"
+    }
+  ]
 }
 EOF
 

--- a/sample-developer-environment.yml
+++ b/sample-developer-environment.yml
@@ -1073,8 +1073,8 @@ Resources:
                   - logs:PutLogEvents
                   - logs:DescribeLogStreams
                 Resource:
-                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/code-server/${PrefixCode}
-                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/code-server/${PrefixCode}:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/ec2/${PrefixCode}-codeserver
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/ec2/${PrefixCode}-codeserver:*
         - PolicyName: !Sub ${PrefixCode}-iampolicy-codeserver-KMS
           PolicyDocument:
             Version: 2012-10-17
@@ -1157,6 +1157,8 @@ Resources:
           Value: !Sub ${EnvironmentTag}
   ec2loggroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       LogGroupName: !Sub /aws/ec2/${PrefixCode}-codeserver
       RetentionInDays: 14
@@ -1184,7 +1186,7 @@ Resources:
                 "collect_list": [
                   {
                     "file_path": "/var/log/cloud-init-output.log",
-                    "log_group_name": "/aws/code-server/${PrefixCode}",
+                    "log_group_name": "/aws/ec2/${PrefixCode}-codeserver",
                     "log_stream_name": "setup"
                   }
                 ]
@@ -1314,6 +1316,7 @@ Resources:
           echo "- Setup log: $SETUP_LOG"
 
           echo "INFO: Bootstrap process completed at $(date)"
+          /opt/aws/bin/cfn-signal -e $SETUP_EXIT_CODE --stack ${AWS::StackName} --region ${AWS::Region} --resource=ec2codeserver
           exit $SETUP_EXIT_CODE
       Tags:
         - Key: Name
@@ -1326,6 +1329,10 @@ Resources:
           Value: compute
         - Key: environment
           Value: !Sub ${EnvironmentTag}
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: PT15M
     Metadata:
       cdk_nag:
         rules_to_suppress:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use cfn-signal to inform Cloudformation about the correct or not execution of the bootstrap script inside the VSCode server EC2 instance. Small fixes for logs on CloudWatch and some changes to settings.json to improve usability

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
